### PR TITLE
Add generation of MAC addresses

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@
 
 - Reorganize internal/config to move VM action logic outside of config, eg. vm/vm.go
 - Generate HDD if it doesn't already exist
-- Generate MAC for tap interfaces if not specified, store in .run/vm/\<name\>/\<net\>_mac
 - Check write privs on run_dir, pid, and tty in Validate()
 - Check write privs on hdd, read privs on cdrom
 - Add template support for kexec cmdline for IP, ssh public
@@ -62,7 +61,6 @@ Configuring Network: "net0"
 cmd: ifconfig bridge1 192.168.99.1 netmask 0xffffff00
 cmd: ifconfig bridge1 192.168.99.1 netmask 0xffffff00
 
-
 ## Completed
 
 - Add arg to each relevant command to work on specific VM
@@ -78,3 +76,4 @@ cmd: ifconfig bridge1 192.168.99.1 netmask 0xffffff00
 - Add pid in status output
 - Add CI, CircleCI, clean code, etc.
 - Generate UUID if not specified, store in .run/vm/\<name\>/uuid
+- Generate MAC for tap interfaces if not specified, store in .run/vm/\<name\>/\<net\>_mac

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+func pidFile(path string) (int, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return 0, fmt.Errorf("pid file not found")
+	}
+	pidTxt, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("pid file cannot be read")
+	}
+
+	pid, err := strconv.Atoi(string(pidTxt))
+	if err != nil {
+		return 0, fmt.Errorf("pid file does not contain an integer")
+	}
+
+	return pid, nil
+}
+
+func uuidFile(path string) (uuid.UUID, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return [16]byte{}, fmt.Errorf("uuid file not found")
+	}
+	uuidTxt, err := ioutil.ReadFile(path)
+	if err != nil {
+		return [16]byte{}, fmt.Errorf("uuid file cannot be read")
+	}
+
+	uuid, err := uuid.Parse(string(uuidTxt))
+	if err != nil {
+		return [16]byte{}, fmt.Errorf("uuid file does not contain an UUID")
+	}
+
+	return uuid, nil
+}
+
+func hwaddrFile(path string) (net.HardwareAddr, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, fmt.Errorf("mac addr file not found")
+	}
+	hwaddrTxt, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("mac addr file cannot be read")
+	}
+
+	hwaddr, err := net.ParseMAC(string(hwaddrTxt))
+	if err != nil {
+		return nil, fmt.Errorf("mac addr file does not contain a hardware address")
+	}
+
+	return hwaddr, nil
+}

--- a/internal/config/network.go
+++ b/internal/config/network.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/rand"
 	"fmt"
 	"net"
 	"strings"
@@ -128,4 +129,20 @@ func (v *VPNKit) Up() error {
 
 func (v *VPNKit) Destroy() error {
 	return nil
+}
+
+// genMAC creates a random 6 byte hardware address, eg. MAC address.
+// The address generated has the locally administered bit set and
+// is a unicast address.
+func genMAC() (net.HardwareAddr, error) {
+	buf := make([]byte, 6)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set local bit, ensure unicast address
+	buf[0] = (buf[0] | 2) & 0xfe
+
+	return buf, nil
 }


### PR DESCRIPTION
1. Add generation of MAC addresses when not specified in the configuration file for a TAP net type. 
2. Move pidFile() and uuidFile() to a new file internal/config/file.go along with a new hwaddrFile() function.